### PR TITLE
Created java 17 jitpack.yml support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 
     compileOnly("me.clip:placeholderapi:2.11.5")
 
-    val commandapiVersion = "9.3.0"
+    val commandapiVersion = "9.5.3"
     implementation("dev.jorel:commandapi-bukkit-shade:$commandapiVersion")
     compileOnly("dev.jorel:commandapi-annotations:$commandapiVersion")
     annotationProcessor("dev.jorel:commandapi-annotations:$commandapiVersion")

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17


### PR DESCRIPTION
Fixes jitpack support
(Basically, it uses Java 8 by default which errors during compilation, so this sets it to use Java 17 instead)